### PR TITLE
신곡 탭 화면 데이터로직 구현

### DIFF
--- a/NANO/Application/AppState.swift
+++ b/NANO/Application/AppState.swift
@@ -14,6 +14,5 @@ class AppState {
     private init() {}
     
     var brand: String = ""
-    
-    var searchingItem: String = "title="
 }
+

--- a/NANO/Application/AppState.swift
+++ b/NANO/Application/AppState.swift
@@ -15,5 +15,5 @@ class AppState {
     
     var brand: String = ""
     
-    var searchingItem: String = "title"
+    var searchingItem: String = "title="
 }

--- a/NANO/Domain/UseCases/SearchUseCase.swift
+++ b/NANO/Domain/UseCases/SearchUseCase.swift
@@ -19,8 +19,13 @@ final class SearchUseCase {
 
 extension SearchUseCase {
     
+    //MARK: - Singer
+    func getSearchingSinger(brand: String, singer: String) -> Observable<SongsResponse> {
+        return networks.getData(url: self.networks.getSearchURL() + "brand=\(brand)&singer=\(singer)")
+    }
+    
     //MARK: - Title
-    func getSearching(brand: String, text: String) -> Observable<SongsResponse> {
-        return networks.getData(url: self.networks.getSearchURL() + "brand=\(brand)&\(text)")
+    func getSearchingTitle(brand: String, title: String) -> Observable<SongsResponse> {
+        return networks.getData(url: self.networks.getSearchURL() + "brand=\(brand)&title=\(title)")
     }
 }

--- a/NANO/Domain/UseCases/SearchUseCase.swift
+++ b/NANO/Domain/UseCases/SearchUseCase.swift
@@ -20,12 +20,7 @@ final class SearchUseCase {
 extension SearchUseCase {
     
     //MARK: - Title
-    func getSearchTitle(brand: String, title: String) -> Observable<SongsResponse> {
-        return networks.getData(url: self.networks.getSearchURL() + "brand=\(brand)&title=\(title)")
-    }
-    
-    //MARK: - Singer
-    func getSearchSinger(brand: String, singer: String) -> Observable<SongsResponse> {
-        return networks.getData(url: self.networks.getReleaseURL() + "brand=\(brand)&singer=\(singer)")
+    func getSearching(brand: String, text: String) -> Observable<SongsResponse> {
+        return networks.getData(url: self.networks.getSearchURL() + "brand=\(brand)&\(text)")
     }
 }

--- a/NANO/Presentation/ViewControllers/ReleaseViewController.swift
+++ b/NANO/Presentation/ViewControllers/ReleaseViewController.swift
@@ -69,9 +69,9 @@ extension ReleaseViewController {
             .withLatestFrom(output.releaseSongs) { index, items -> SongInfo in
             return items[index.row]
         }
-        .subscribe(onNext: { item in
+        .subscribe(onNext: { [weak self] item in
             
-            guard let snapshotView = self.view.snapshotView(afterScreenUpdates: true) else {
+            guard let snapshotView = self?.view.snapshotView(afterScreenUpdates: true) else {
                 return
             }
             
@@ -85,7 +85,7 @@ extension ReleaseViewController {
             popUpVC.modalTransitionStyle = .crossDissolve
             popUpVC.modalPresentationStyle = .fullScreen
             
-            self.present(popUpVC, animated: true)
+            self?.present(popUpVC, animated: true)
         })
         .disposed(by: disposbag)
     }

--- a/NANO/Presentation/ViewControllers/SearchViewController.swift
+++ b/NANO/Presentation/ViewControllers/SearchViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 final class SearchViewController: UIViewController {
     
     //MARK: - Declaration
+    private lazy var viewModel = SearchViewModel()
+    
     private lazy var searchView: SearchView = {
         let view = SearchView()
         view.songInfoTableView.dataSource = self
@@ -27,6 +29,7 @@ final class SearchViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setSegmentedControl()
         self.navigationItem.title = "검색"
         self.tabBarController?.navigationItem.title = "검색"
     }
@@ -36,7 +39,28 @@ final class SearchViewController: UIViewController {
         self.view.endEditing(true)
     }
 }
-
+extension SearchViewController {
+    
+    //MARK: - Function
+    private func setSegmentedControl() {
+        
+        searchView.singerTitleSegmentedControl.selectedSegmentIndex = 0
+        searchView.singerTitleSegmentedControl.addTarget(self, action: #selector(indexChanged(_:)), for: .valueChanged)
+    }
+    
+    //MARK: - Selector
+    @objc func indexChanged(_ sender: UISegmentedControl) {
+        
+        switch sender.selectedSegmentIndex {
+        case 0:
+            viewModel.searchingItem = .title
+        case 1:
+            viewModel.searchingItem = .singer
+        default:
+            viewModel.searchingItem = .title
+        }
+    }
+}
 //MARK: - Delegate, DataSource
 extension SearchViewController: UITableViewDelegate, UITableViewDataSource {
     

--- a/NANO/Presentation/ViewModels/ReleaseViewModel.swift
+++ b/NANO/Presentation/ViewModels/ReleaseViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RxSwift
+import RxCocoa
 
 final class ReleaseViewModel: ViewModel {
     
@@ -22,7 +23,7 @@ final class ReleaseViewModel: ViewModel {
         }
         .map { response in
             return response.data
-        }
+        }.asDriver(onErrorJustReturn: .init())
         
         return Output(releaseSongs: releaseSongs)
     }
@@ -37,6 +38,6 @@ extension ReleaseViewModel {
     
     //MARK: - Output
     struct Output {
-        let releaseSongs: Observable<[SongInfo]>
+        let releaseSongs: Driver<[SongInfo]>
     }
 }

--- a/NANO/Presentation/ViewModels/SearchViewModel.swift
+++ b/NANO/Presentation/ViewModels/SearchViewModel.swift
@@ -8,18 +8,30 @@
 import Foundation
 import RxSwift
 
+enum SearchParameter {
+    case title
+    case singer
+}
+
 final class SearchViewModel: ViewModel {
     
     //MARK: - Declaration
     var disposeBag = DisposeBag()
     let searchUseCase = SearchUseCase.shared
+    var searchingItem: SearchParameter = .title
     
     //MARK: - Transform
     func transform(input: Input) -> Output {
         let searchingResult = input.tapSearching
             .withLatestFrom(input.searchedText)
             .flatMap { text in
-                return self.searchUseCase.getSearching(brand: AppState.shared.brand, text: AppState.shared.searchingItem + text)
+                
+                switch self.searchingItem {
+                case .title:
+                    return  self.searchUseCase.getSearchingTitle(brand: AppState.shared.brand, title: text)
+                case .singer:
+                    return  self.searchUseCase.getSearchingSinger(brand: AppState.shared.brand, singer: text)
+                }
             }
             .map { response in
                 return response.data

--- a/NANO/Presentation/ViewModels/SearchViewModel.swift
+++ b/NANO/Presentation/ViewModels/SearchViewModel.swift
@@ -12,15 +12,14 @@ final class SearchViewModel: ViewModel {
     
     //MARK: - Declaration
     var disposeBag = DisposeBag()
-    let search = SearchUseCase.shared
-    let appState = AppState.shared
+    let searchUseCase = SearchUseCase.shared
     
     //MARK: - Transform
     func transform(input: Input) -> Output {
         let searchingResult = input.tapSearching
             .withLatestFrom(input.searchedText)
             .flatMap { text in
-                return self.search.getSearchTitle(brand: self.appState.brand, title: text)
+                return self.searchUseCase.getSearching(brand: AppState.shared.brand, text: AppState.shared.searchingItem + text)
             }
             .map { response in
                 return response.data

--- a/NANO/Presentation/Views/PopUp/SubViews/SongDetailInfoView.swift
+++ b/NANO/Presentation/Views/PopUp/SubViews/SongDetailInfoView.swift
@@ -61,6 +61,7 @@ final class SongDetailInfoView: UIView, ContentViewDelegating {
         let label = UILabel()
         label.textColor = .label
         label.font = .labelText
+        label.numberOfLines = 0
         label.sizeToFit()
         
         return label
@@ -70,6 +71,7 @@ final class SongDetailInfoView: UIView, ContentViewDelegating {
         let label = UILabel()
         label.textColor = .label
         label.font = .labelText
+        label.numberOfLines = 0
         label.sizeToFit()
         
         return label
@@ -79,6 +81,7 @@ final class SongDetailInfoView: UIView, ContentViewDelegating {
         let label = UILabel()
         label.textColor = .label
         label.font = .labelText
+        label.numberOfLines = 0
         label.sizeToFit()
         
         return label

--- a/NANO/Presentation/Views/Search/SearchView.swift
+++ b/NANO/Presentation/Views/Search/SearchView.swift
@@ -86,11 +86,11 @@ extension SearchView {
         
         switch sender.selectedSegmentIndex {
         case 0:
-            AppState.shared.searchingItem = "title"
+            AppState.shared.searchingItem = "title="
         case 1:
-            AppState.shared.searchingItem = "singer"
+            AppState.shared.searchingItem = "singer="
         default:
-            AppState.shared.searchingItem = "title"
+            AppState.shared.searchingItem = "title="
         }
     }
 }

--- a/NANO/Presentation/Views/Search/SearchView.swift
+++ b/NANO/Presentation/Views/Search/SearchView.swift
@@ -11,11 +11,9 @@ import SnapKit
 final class SearchView: UIView {
     
     //MARK: - Declaration
-    private lazy var singerTitleSegmentedControl: UISegmentedControl = {
+    lazy var singerTitleSegmentedControl: UISegmentedControl = {
         let segmentedControl = UISegmentedControl(items: ["제목","가수"])
         segmentedControl.backgroundColor = .main
-        segmentedControl.selectedSegmentIndex = 0
-        segmentedControl.addTarget(self, action: #selector(indexChanged(_:)), for: .valueChanged)
 
         return segmentedControl
     }()
@@ -76,21 +74,6 @@ extension SearchView {
             make.top.equalTo(searchBar.snp.bottom).offset(calculatingHeight(height: 40))
             make.horizontalEdges.equalToSuperview().inset(calculatingWidth(width: 18))
             make.bottom.equalTo(safeAreaLayoutGuide.snp.bottom).inset(calculatingHeight(height: 20))
-        }
-    }
-}
-
-//MARK: - Selector
-extension SearchView {
-    @objc func indexChanged(_ sender: UISegmentedControl) {
-        
-        switch sender.selectedSegmentIndex {
-        case 0:
-            AppState.shared.searchingItem = "title="
-        case 1:
-            AppState.shared.searchingItem = "singer="
-        default:
-            AppState.shared.searchingItem = "title="
         }
     }
 }


### PR DESCRIPTION
- SearchUseCase를 제목, 검색을 따로 나누지 않고 단순하게 통합시켜서 사용할때에 더 편하게 변경
- rx.items 를 이용하여 tableView의 DataSource가 필요 없게끔 변경
- rx.itemSelected을 이용하여 tableView의 Delegate가 필요 없게끔 변경